### PR TITLE
feat: Criação do auth.guard para autenticação

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser-dynamic": "^19.1.0",
         "@angular/router": "^19.1.0",
         "json-server": "^1.0.0-beta.3",
+        "jwt-decode": "^4.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -9389,6 +9390,14 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/karma": {
       "version": "6.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser-dynamic": "^19.1.0",
     "@angular/router": "^19.1.0",
     "json-server": "^1.0.0-beta.3",
+    "jwt-decode": "^4.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -2,6 +2,8 @@ import { Routes } from "@angular/router";
 import { RegisterComponent } from "./auth/register/register.component";
 import { LoginComponent } from "./auth/login/login.component";
 import { HomeComponent } from "./home/home.component";
+import { UnauthorizedComponent } from "./auth/unauthorized/unauthorized.component";
+import { authGuard } from "./auth/auth.guard";
 
 
 const routeConfig: Routes = [
@@ -15,7 +17,17 @@ const routeConfig: Routes = [
     },
     { 
         path: 'home', component: HomeComponent, 
+        canActivate: [authGuard],
         title: 'Home' 
+    },
+    { 
+        path: 'home/admin', component: HomeComponent, 
+        canActivate: [authGuard],
+        data: {role: 'admin'},
+        title: 'Teste filtro de role' 
+    },
+    {
+        path: 'unauthorized', component: UnauthorizedComponent, title: 'Unauthorized'
     },
 ]; 
 

--- a/frontend/src/app/auth/auth.guard.spec.ts
+++ b/frontend/src/app/auth/auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/frontend/src/app/auth/auth.guard.ts
+++ b/frontend/src/app/auth/auth.guard.ts
@@ -1,0 +1,20 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, ActivatedRouteSnapshot } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  const requiredRole: string | undefined = route.data?.['role'];
+
+  if (!authService.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
+  }
+
+  if (requiredRole && !authService.hasRole(requiredRole)) {
+    return router.createUrlTree(['/unauthorized'])
+  }
+
+  return true;
+};

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { User } from './user';
+import { jwtDecode } from 'jwt-decode';
 
 @Injectable({
   providedIn: 'root'
@@ -48,7 +49,21 @@ export class AuthService {
       return false;
     }
   }
-
+  
+  hasRole(requiredRole: string): boolean {
+    const token = this.getToken();
+    if (!token) {
+      return false;
+    }
+    try {
+      const decodedToken: any = jwtDecode(token);
+      return decodedToken.role === requiredRole;
+    } catch (error) {
+      console.error('Token error:', error);
+      return false;
+    }
+  }
+  
   logout(): void {
     localStorage.removeItem('token');
   }
@@ -58,6 +73,10 @@ export class AuthService {
   }
 
   isLoggedIn(): boolean {
+    return !!this.getToken();
+  }
+
+  isAuthenticated(): boolean {
     return !!this.getToken();
   }
 

--- a/frontend/src/app/auth/unauthorized/unauthorized.component.spec.ts
+++ b/frontend/src/app/auth/unauthorized/unauthorized.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UnauthorizedComponent } from './unauthorized.component';
+
+describe('UnauthorizedComponent', () => {
+  let component: UnauthorizedComponent;
+  let fixture: ComponentFixture<UnauthorizedComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UnauthorizedComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(UnauthorizedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/auth/unauthorized/unauthorized.component.ts
+++ b/frontend/src/app/auth/unauthorized/unauthorized.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-unauthorized',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <p>
+      Seu usuário não tem permissão para acessar essa página.
+    </p>
+  `,
+  styleUrls: ['./unauthorized.component.css']
+})
+export class UnauthorizedComponent {
+
+}


### PR DESCRIPTION
Novas dependências: jwt-decoder

Criação do auth.guard para filtrar usuários não autenticados ou usuários sem permissão de aceite na página.
Criação de uma página e rota para avisar que não tem autorização. (unauthorized)
Criação de uma rota para testar permissões de entrada pela role.
Novos métodos no auth.service para auxiliar na verificação e validação da autenticação/autorização