### PR TITLE
feat: adição da proteção do endpoint receitas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 backend/.env
 backend/docker-compose.yml
+
+### VS Code ###
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/backend/src/main/java/br/com/gestorfinanceiro/config/SecurityConfig.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/config/SecurityConfig.java
@@ -36,8 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**").permitAll() // Rotas públicas
                         .requestMatchers("/users/admin/**").hasRole("ADMIN")
                         .requestMatchers("/users/**").authenticated() // Rotas protegidas
-                        .requestMatchers(HttpMethod.POST, "/receitas/**").hasAnyRole("ADMIN", "USER") // Apenas USER e ADMIN podem criar receita
-                        .requestMatchers("/receitas/**").authenticated() // Receitas: demais ações protegidas
+                        .requestMatchers("/receitas/**").hasAnyRole("ADMIN", "USER") // Apenas USER e ADMIN podem acessar as rotas de receitas
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandling -> exceptionHandling

--- a/backend/src/main/java/br/com/gestorfinanceiro/config/SecurityConfig.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/config/SecurityConfig.java
@@ -36,6 +36,8 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**").permitAll() // Rotas públicas
                         .requestMatchers("/users/admin/**").hasRole("ADMIN")
                         .requestMatchers("/users/**").authenticated() // Rotas protegidas
+                        .requestMatchers(HttpMethod.POST, "/receitas/**").hasAnyRole("ADMIN", "USER") // Apenas USER e ADMIN podem criar receita
+                        .requestMatchers("/receitas/**").authenticated() // Receitas: demais ações protegidas
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptionHandling -> exceptionHandling


### PR DESCRIPTION
Ajuste no SecurityConfig para garantir que apenas usuários autenticados com roles USER ou ADMIN possam criar receitas (POST), enquanto as demais ações de receitas permanecem protegidas.