### PR TITLE
Adiciona funcionalidade para geração de gráfico de barras de despesas por período

### DIFF
--- a/backend/src/main/java/br/com/gestorfinanceiro/controller/DespesaController.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/controller/DespesaController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.YearMonth;
 import java.util.List;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
@@ -85,6 +86,14 @@ public class DespesaController {
     public ResponseEntity<Void> excluirDespesa(@PathVariable String id) {
         despesaService.excluirDespesa(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/grafico-barras")
+    public ResponseEntity<?> gerarGraficoBarrasDespesa(@RequestParam YearMonth inicio, @RequestParam YearMonth fim, HttpServletRequest request) {
+        String token = request.getHeader("Authorization").replace("Bearer ", "");
+        String userId = jwtUtil.extractUserId(token);
+
+        return ResponseEntity.ok(despesaService.gerarGraficoBarras(userId, inicio, fim));
     }
 }
 

--- a/backend/src/main/java/br/com/gestorfinanceiro/dto/GraficoBarraDTO.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/dto/GraficoBarraDTO.java
@@ -1,0 +1,6 @@
+package br.com.gestorfinanceiro.dto;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record GraficoBarraDTO(Map<String , BigDecimal> dadosMensais) {}

--- a/backend/src/main/java/br/com/gestorfinanceiro/repositories/DespesaRepository.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/repositories/DespesaRepository.java
@@ -1,12 +1,13 @@
 package br.com.gestorfinanceiro.repositories;
 
 import br.com.gestorfinanceiro.models.DespesaEntity;
+import br.com.gestorfinanceiro.repositories.custom.DespesaRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface DespesaRepository extends JpaRepository<DespesaEntity, String> {
+public interface DespesaRepository extends JpaRepository<DespesaEntity, String>, DespesaRepositoryCustom {
     List<DespesaEntity> findAllByUserUuid(String userId);
 }

--- a/backend/src/main/java/br/com/gestorfinanceiro/repositories/custom/DespesaRepositoryCustom.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/repositories/custom/DespesaRepositoryCustom.java
@@ -1,0 +1,12 @@
+package br.com.gestorfinanceiro.repositories.custom;
+
+import br.com.gestorfinanceiro.models.DespesaEntity;
+import org.springframework.stereotype.Repository;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Repository
+public interface DespesaRepositoryCustom {
+    List<DespesaEntity>findByUserAndYearMonthRange (String userId, YearMonth inicio, YearMonth fim);
+}

--- a/backend/src/main/java/br/com/gestorfinanceiro/repositories/custom/impl/DespesaRepositoryCustomImpl.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/repositories/custom/impl/DespesaRepositoryCustomImpl.java
@@ -1,0 +1,29 @@
+package br.com.gestorfinanceiro.repositories.custom.impl;
+
+import br.com.gestorfinanceiro.models.DespesaEntity;
+import br.com.gestorfinanceiro.repositories.custom.DespesaRepositoryCustom;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Repository
+public class DespesaRepositoryCustomImpl implements DespesaRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+
+    @Override
+    public List<DespesaEntity> findByUserAndYearMonthRange(String userId, YearMonth inicio, YearMonth fim) {
+        String jpql = "SELECT d FROM DespesaEntity d WHERE d.user.uuid = :userId AND d.data BETWEEN :inicio AND :fim ORDER BY d.data";
+
+        return entityManager.createQuery(jpql, DespesaEntity.class)
+                .setParameter("userId", userId)
+                .setParameter("inicio", inicio.atDay(1))
+                .setParameter("fim", fim.atEndOfMonth())
+                .getResultList();
+    }
+}

--- a/backend/src/main/java/br/com/gestorfinanceiro/services/DespesaService.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/services/DespesaService.java
@@ -2,8 +2,9 @@ package br.com.gestorfinanceiro.services;
 
 import br.com.gestorfinanceiro.models.DespesaEntity;
 
+import java.time.YearMonth;
 import java.util.List;
-import java.util.Optional;
+import br.com.gestorfinanceiro.dto.GraficoBarraDTO;
 
 public interface DespesaService {
 
@@ -16,4 +17,6 @@ public interface DespesaService {
     DespesaEntity atualizarDespesa(String uuid, DespesaEntity despesaAtualizada);
 
     void excluirDespesa(String uuid);
+
+    GraficoBarraDTO gerarGraficoBarras(String userId, YearMonth inicio, YearMonth fim);
 }


### PR DESCRIPTION
### Novo Recurso: Geração de Gráfico de Barras para Despesas  

Este pull request introduz uma nova funcionalidade para gerar gráficos de barras de despesas dentro de um intervalo de datas especificado. Ele inclui alterações em vários arquivos para implementar essa funcionalidade.  

### **Principais Alterações:**  

#### **📌 Atualização no Controller:**  
- Adicionado um novo endpoint `gerarGraficoBarrasDespesa` no `DespesaController` para lidar com as requisições de geração de gráficos de barras.  
- O endpoint aceita parâmetros `YearMonth` para as datas de início e fim e retorna os dados do gráfico de barras.  

#### **📌 Criação de DTO:**  
- Criada a classe `GraficoBarraDTO` para encapsular os dados do gráfico de barras, incluindo um mapa de dados mensais.  

#### **📌 Melhorias no Repositório:**  
- Atualizado `DespesaRepository` para estender `DespesaRepositoryCustom`, permitindo consultas personalizadas.  
- Adicionada a interface `DespesaRepositoryCustom` para declarar um método que recupera despesas dentro de um intervalo de datas.  
- Implementado `DespesaRepositoryCustomImpl` para fornecer a lógica personalizada de consulta de despesas por usuário e período.  

#### **📌 Modificações na Camada de Serviço:**  
- Atualizado `DespesaService` para incluir um método de geração de dados do gráfico de barras.  
- Implementado o novo método em `DespesaServiceImpl` para processar os dados das despesas e formatá-los para o gráfico, agrupando por mês e somando os valores.  