### PR TITLE
feat: adição no global handler dos erros gerados pela receita

### DIFF
--- a/backend/src/main/java/br/com/gestorfinanceiro/dto/ReceitaDTO.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/dto/ReceitaDTO.java
@@ -29,7 +29,17 @@ public class ReceitaDTO {
     @NotBlank(message = "As observações são obrigatórias.")
     private String observacoes;
 
+    private String uuid; // Pegar o ID para rotas específicas
+
     // Getters and Setters
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
     public LocalDate getData() {
         return data;
     }

--- a/backend/src/main/java/br/com/gestorfinanceiro/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/exceptions/GlobalExceptionHandler.java
@@ -53,6 +53,33 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return buildErrorResponse(HttpStatus.CONFLICT, ex.getMessage());
     }
 
+    // Handler para quando a receita não for encontrada
+    @ExceptionHandler(ReceitaNotFoundException.class)
+    public ResponseEntity<ApiError> handleReceitaNotFoundException(ReceitaNotFoundException ex) {
+        logException("Receita não encontrada", ex);
+
+        // Criando um Map para adicionar detalhes ao campo errors
+        Map<String, String> errors = Map.of(
+                "Detalhes do erro", "Não há receitas para este usuário ou o usuário não existe."
+        );
+
+        ApiError apiError = new ApiError(HttpStatus.NOT_FOUND, ex.getMessage(), errors);
+        return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
+    }
+
+    // Handler para erros operacionais relacionados à receita
+    @ExceptionHandler(ReceitaOperationException.class)
+    public ResponseEntity<ApiError> handleReceitaOperationException(ReceitaOperationException ex) {
+        logException("Erro na operação com receita", ex);
+
+        Map<String, String> errors = Map.of(
+                "Detalhes do erro", ex.getCause() != null ? ex.getCause().getMessage() : "Erro desconhecido"
+        );
+
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST, "Erro ao atualizar receita. Por favor, tente novamente.", errors);
+        return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
+    }
+
     // Handler para erros de parse de JSON na requisição (ex: JSON malformado, formato de data inválido, tipos incompatíveis)
     @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(
@@ -124,32 +151,5 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             ex = ex.getCause();
         }
         return false;
-    }
-
-    // Handler para quando a receita não for encontrada
-    @ExceptionHandler(ReceitaNotFoundException.class)
-    public ResponseEntity<ApiError> handleReceitaNotFoundException(ReceitaNotFoundException ex) {
-        logException("Receita não encontrada", ex);
-
-        // Criando um Map para adicionar detalhes ao campo errors
-        Map<String, String> errors = Map.of(
-            "Detalhes do erro", "Não há receitas para este usuário ou o usuário não existe."
-        );
-
-        ApiError apiError = new ApiError(HttpStatus.NOT_FOUND, ex.getMessage(), errors);
-        return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
-    }
-
-    // Handler para erros operacionais relacionados à receita
-    @ExceptionHandler(ReceitaOperationException.class)
-    public ResponseEntity<ApiError> handleReceitaOperationException(ReceitaOperationException ex) {
-        logException("Erro na operação com receita", ex);
-
-        Map<String, String> errors = Map.of(
-            "Detalhes do erro", ex.getCause() != null ? ex.getCause().getMessage() : "Erro desconhecido"
-        );
-        
-        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST, "Erro ao atualizar receita. Por favor, tente novamente.", errors);
-        return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/br/com/gestorfinanceiro/exceptions/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/gestorfinanceiro/exceptions/GlobalExceptionHandler.java
@@ -4,6 +4,9 @@ import br.com.gestorfinanceiro.exceptions.auth.login.EmailNotFoundException;
 import br.com.gestorfinanceiro.exceptions.auth.login.InvalidPasswordException;
 import br.com.gestorfinanceiro.exceptions.auth.register.EmailAlreadyExistsException;
 import br.com.gestorfinanceiro.exceptions.auth.register.UsernameAlreadyExistsException;
+import br.com.gestorfinanceiro.exceptions.receita.ReceitaNotFoundException;
+import br.com.gestorfinanceiro.exceptions.receita.ReceitaOperationException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -123,4 +126,30 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return false;
     }
 
+    // Handler para quando a receita não for encontrada
+    @ExceptionHandler(ReceitaNotFoundException.class)
+    public ResponseEntity<ApiError> handleReceitaNotFoundException(ReceitaNotFoundException ex) {
+        logException("Receita não encontrada", ex);
+
+        // Criando um Map para adicionar detalhes ao campo errors
+        Map<String, String> errors = Map.of(
+            "Detalhes do erro", "Não há receitas para este usuário ou o usuário não existe."
+        );
+
+        ApiError apiError = new ApiError(HttpStatus.NOT_FOUND, ex.getMessage(), errors);
+        return new ResponseEntity<>(apiError, HttpStatus.NOT_FOUND);
+    }
+
+    // Handler para erros operacionais relacionados à receita
+    @ExceptionHandler(ReceitaOperationException.class)
+    public ResponseEntity<ApiError> handleReceitaOperationException(ReceitaOperationException ex) {
+        logException("Erro na operação com receita", ex);
+
+        Map<String, String> errors = Map.of(
+            "Detalhes do erro", ex.getCause() != null ? ex.getCause().getMessage() : "Erro desconhecido"
+        );
+        
+        ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST, "Erro ao atualizar receita. Por favor, tente novamente.", errors);
+        return new ResponseEntity<>(apiError, HttpStatus.BAD_REQUEST);
+    }
 }


### PR DESCRIPTION
Modificações:

1. **Tratamento de Exceções no Global Handler:**
   - Foram adicionados dois novos handlers para tratar erros específicos relacionados às receitas:
     - `ReceitaNotFoundException`: Quando uma receita não for encontrada, a resposta incluirá uma mensagem mais detalhada sobre o erro, além de um mapa com informações adicionais.
     - `ReceitaOperationException`: Para erros operacionais (como falha na criação ou atualização de uma receita), a resposta inclui a causa do erro, se disponível, no campo `errors`.

2. **Ajuste no DTO da Receita:**
   - O campo `uuid` foi adicionado no `ReceitaDTO` para garantir que o ID da receita seja retornado corretamente nas respostas, permitindo a realização de testes e garantindo a manipulação correta do UUID nas rotas específicas.
