### PR TITLE
feat: configuração do ambiente de teste com application-test.properties e ajuste no pom.xml

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,27 @@
+name: CI/CD Backend
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v4
+
+      - name: Configurar JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: maven
+
+      - name: Compilar e rodar testes com perfil de testes
+        run: mvn clean verify -Dspring.profiles.active=test

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -23,5 +23,8 @@ jobs:
           java-version: '21'
           cache: maven
 
+      - name: Navegar para o diretório backend
+        run: cd backend
+
       - name: Compilar e rodar testes com perfil de testes
         run: mvn clean verify -Dspring.profiles.active=test

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -23,8 +23,5 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Navegar para o diretório backend
-        run: cd backend
-
       - name: Compilar e rodar testes com perfil de testes
-        run: mvn clean verify -Dspring.profiles.active=test
+        run: cd backend && mvn clean verify -Dspring.profiles.active=test

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -95,6 +95,12 @@
 			<artifactId>jaxb-api</artifactId>
 			<version>2.3.1</version>
 		</dependency>
+
+		<dependency>
+     		<groupId>com.h2database</groupId>
+     		<artifactId>h2</artifactId>
+     		<scope>test</scope>
+ 		</dependency>
 	</dependencies>
 
 	<build>
@@ -115,5 +121,19 @@
 		</plugins>
 	</build>
 
+	<profiles>
+    	<profile>
+        	<id>test</id>
+        	<activation>
+            	<property>
+                	<name>env</name>
+                	<value>test</value>
+            	</property>
+        	</activation>
+        	<properties>
+            	<spring.profiles.active>test</spring.profiles.active>
+        	</properties>
+    	</profile>
+	</profiles>
 
 </project>

--- a/backend/src/main/resources/application-test.properties
+++ b/backend/src/main/resources/application-test.properties
@@ -1,0 +1,32 @@
+# Nome da aplicação no ambiente de testes
+spring.application.name=gestorfinanceiro-test
+
+# Configuração do banco de dados H2 (em memória) para testes
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Configuração do Hibernate para H2
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# Habilitar o console do H2 para debug
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# Criar e dropar tabelas automaticamente nos testes
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# Exibir SQL no console para debug durante os testes
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# Configuração do Logging para testes
+logging.level.org.springframework=DEBUG
+logging.level.br.com.gestorfinanceiro=DEBUG
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql=TRACE
+
+# Configuração do JWT para testes (usando valores fixos)
+jwt.secret=test-secret-key
+jwt.expiration=86400000


### PR DESCRIPTION
**Mudanças:**

- Configuração do perfil `test` no `pom.xml` para rodar testes com o ambiente de H2 em memória.
- Adicionado o arquivo `application-test.properties` com as propriedades para usar o banco H2 e as propriedades necessárias para o ambiente de testes.
- O workflow do GitHub Actions foi configurado para rodar os testes automaticamente na branch `main` utilizando o Maven com o perfil de testes.